### PR TITLE
fixing typo in the readme for installing the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/PRX/PRXPlayer
 
 2. Install this plugin using PhoneGap/Cordova cli:
 
-        cordova local plugin add https://github.com/wnyc/cordova-plugin-playerhater.git
+        cordova plugin add https://github.com/wnyc/cordova-plugin-playerhater.git
 
 ## Usage
 


### PR DESCRIPTION
If you try to use `cordova local` it throws an error:

Cordova does not know local; try `cordova help`....

Removing it and running `cordova plugin add...` installs the plugin as expected
